### PR TITLE
Prevent Flow boards from being created by default

### DIFF
--- a/matchbot/matchbot/mbapi.py
+++ b/matchbot/matchbot/mbapi.py
@@ -30,7 +30,9 @@ def flowenabled(title, site):
     pagedict = query['query']['pages']
     for page in pagedict:
         if page == '-1':
-            return None
+#            return None
+######## HACK BECAUSE CREATING FLOW BOARDS IS NOT ENABLED #########
+            return False
         else:
             return (u'enabled' in pagedict[page]['flowinfo']['flow'])
 


### PR DESCRIPTION
HACK. Edit mbapi.py to return False when the bot checks for whether
Flow has been enabled on a nonexistent page, thus sending it to the
workflow for a known non-Flow page.

Easily taken out when Flow is accepted.
